### PR TITLE
feat: add get_unsubmitted_timesheets tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ The server provides the following functionality:
 - Create new time entries
 - Start/stop timers
 - Query time entry details
+- Get unsubmitted timesheets (time entries not yet submitted for approval)
 
 ### Projects
 - List projects with filtering options
@@ -77,6 +78,8 @@ Once connected, you can ask Claude about your Harvest data with queries like:
 - "Start a timer for project [project_id] and task [task_id]"
 - "Show me all active clients"
 - "List all available tasks"
+- "Get my unsubmitted timesheets from this month"
+- "Show me unsubmitted time entries for user [user_id]"
 
 ## Customization
 


### PR DESCRIPTION
## Summary
Adds a new MCP tool `get_unsubmitted_timesheets` that allows users to retrieve time entries that haven't been submitted for approval or closed. This is useful for timesheet management workflows where users need to identify and review open time entries.

## Changes
- Added `get_unsubmitted_timesheets()` function to harvest-mcp-server.py
- Filters time entries by `is_closed` status to identify unsubmitted entries
- Supports filtering by user_id, date range (from_date/to_date), and pagination
- Returns filtered response with same structure as standard time entry queries
- Updated README.md with new functionality description and usage examples

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Function follows existing MCP tool patterns
- [x] Proper parameter handling and validation
- [x] JSON response formatting matches existing tools
- [x] Updated documentation reflects new functionality

## Implementation Details
The tool works by:
1. Fetching time entries using existing harvest_request() function
2. Client-side filtering based on `is_closed` field (false = unsubmitted)
3. Returning filtered results in consistent API response format
4. Supporting all standard pagination and filtering parameters

## Usage Examples
- "Get my unsubmitted timesheets from this month"
- "Show me unsubmitted time entries for user 12345"
- "List all open time entries from 2024-01-01 to 2024-01-31"

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Updated documentation
- [x] No debug code or console.logs
- [x] Follows existing MCP tool patterns