### PR TITLE
Fix: Accept 201 status code for POST requests

### DIFF
--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -34,7 +34,7 @@ async def harvest_request(path, params=None, method="GET"):
         else:
             response = await client.request(method, url, headers=headers, json=params)
 
-        if response.status_code != 200:
+        if response.status_code not in (200, 201):
             raise Exception(
                 f"Harvest API Error: {response.status_code} {response.text}"
             )


### PR DESCRIPTION
## Problem
When creating time entries via `create_time_entry` or `start_timer`, the MCP server throws:
```
Harvest API Error: 201 {"id":...}
```
The operation succeeds (time entry is created), but the client sees an error.

## Cause
The Harvest API returns HTTP 201 Created for successful POST requests, but `harvest_request` only accepted 200.

## Fix
Changed status check from `!= 200` to `not in (200, 201)`.

This covers all API calls in the server:
- GET requests → 200 OK
- PATCH requests (stop_timer) → 200 OK  
- POST requests (create_time_entry, start_timer) → 201 Created