### PR TITLE
Fix start_timer

### DIFF
--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -163,6 +163,7 @@ async def start_timer(project_id: int, task_id: int, notes: str = None):
     params = {
         "project_id": project_id,
         "task_id": task_id,
+        "spent_date": datetime.now().strftime("%Y-%m-%d"),
     }
 
     if notes:


### PR DESCRIPTION
add spent_date to start_timer

Current call fails because spent_date is a required field by Harvest API