### PR TITLE
Add optional read-only mode via HARVEST_READ_ONLY env var

### DIFF
--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -16,6 +16,22 @@ if not HARVEST_ACCOUNT_ID or not HARVEST_API_KEY:
         "Missing Harvest API credentials. Set HARVEST_ACCOUNT_ID and HARVEST_API_KEY environment variables."
     )
 
+# Read-only mode: when enabled, write operations return an error message
+# instead of modifying Harvest data.
+HARVEST_READ_ONLY = os.environ.get("HARVEST_READ_ONLY", "").lower() in ("true", "1", "yes")
+
+READ_ONLY_MESSAGE = json.dumps(
+    {
+        "error": "read_only_mode",
+        "message": (
+            "This Harvest MCP server is running in read-only mode. "
+            "To enable write operations, remove the HARVEST_READ_ONLY environment variable "
+            "or set it to 'false' in your MCP server configuration."
+        ),
+    },
+    indent=2,
+)
+
 
 # Helper function to make Harvest API requests
 async def harvest_request(path, params=None, method="GET"):
@@ -128,6 +144,9 @@ async def create_time_entry(
         hours: The number of hours spent
         notes: Optional notes about the time entry
     """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
     params = {
         "project_id": project_id,
         "task_id": task_id,
@@ -149,6 +168,9 @@ async def stop_timer(time_entry_id: int):
     Args:
         time_entry_id: The ID of the running time entry to stop
     """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
     response = await harvest_request(
         f"time_entries/{time_entry_id}/stop", method="PATCH"
     )
@@ -168,6 +190,9 @@ async def start_timer(
         task_id: The ID of the task to associate with the time entry
         notes: Optional notes about the time entry
     """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
     params = {
         "project_id": project_id,
         "task_id": task_id,

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,33 @@ You can modify the server code to add more functionality or customize the existi
 - **Connection Issues**: Verify that your Claude Desktop configuration has the correct path to the server script.
 - **Missing Dependencies**: Ensure you've installed all required packages in your Python environment.
 
+## Read-Only Mode
+
+You can run the server in read-only mode by setting the `HARVEST_READ_ONLY` environment variable to `true`. This disables all write operations (creating time entries, starting timers, and stopping timers) while keeping all read operations available.
+
+```json
+{
+    "mcpServers": {
+        "harvest": {
+            "command": "uv",
+            "args": [
+              "run",
+              "--directory",
+              "change_directory",
+              "harvest-mcp-server.py"
+            ],
+            "env": {
+                "HARVEST_ACCOUNT_ID": "account_id",
+                "HARVEST_API_KEY": "api_key",
+                "HARVEST_READ_ONLY": "true"
+            }
+        }
+    }
+}
+```
+
+When read-only mode is enabled, any attempt to call a write tool will return an error message explaining that the server is in read-only mode and how to enable write access.
+
 ## Security Notes
 
 This server requires your Harvest API credentials to function. Make sure to:


### PR DESCRIPTION
## Summary
- Adds optional read-only mode controlled by the `HARVEST_READ_ONLY` environment variable
- When set to `true`, `1`, or `yes`, all write operations (`create_time_entry`, `start_timer`, `stop_timer`) return an informative error message instead of modifying Harvest data
- Read operations are unaffected
- Documented in readme with config example

## Motivation
When using this MCP with AI assistants, it's useful to be able to grant read access to Harvest data without risking accidental writes. This lets users safely query time entries, projects, and users while preventing any modifications.

## Test plan
- [x] Verified read operations work normally with `HARVEST_READ_ONLY=true`
- [x] Verified `create_time_entry` returns read-only error message
- [x] Verified `start_timer` returns read-only error message
- [x] Verified `stop_timer` returns read-only error message
- [x] Verified all write operations work normally without the env var set