### PR TITLE
Document correct Windows config path for MSIX installs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,10 +39,10 @@ The server provides the following functionality:
 - Harvest API key and Account ID
 
 ### Integrating with Claude Desktop
-
 1. Create or edit your Claude Desktop configuration file:
    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - Windows: `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json`
+   - Windows (MSIX installs — the default from [claude.ai/download](https://claude.ai/download)): `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json`
+   - Windows (older/non-MSIX installs): `%APPDATA%\Claude\claude_desktop_config.json`
 
 2. Add the Harvest MCP server configuration:
    ```json

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ The server provides the following functionality:
 
 1. Create or edit your Claude Desktop configuration file:
    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - Windows: `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json`
 
 2. Add the Harvest MCP server configuration:
    ```json


### PR DESCRIPTION
The current instructions point to %APPDATA%\Claude\claude_desktop_config.json, which is correct for older or non-MSIX Windows installs. However, current Windows builds installed via MSIX (including the official installer from claude.ai/download) use a virtualized path and actually read from:
%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json.

Users on MSIX installs who follow the original instructions end up editing a file the app never reads — the config appears valid, but no MCP servers load and no log files are generated, making it hard to diagnose.

This PR keeps the original path documented and adds the MSIX path as the correct location for current installs. Verified on Windows 11 with Claude Desktop build 1.3036.0.
