### PR TITLE
Add estimates endpoint support (CRUD + messages + state transitions)

### DIFF
--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -349,8 +349,18 @@ async def list_estimates(
     state: str = None,
     page: int = None,
     per_page: int = None,
+    include_line_items: bool = False,
 ):
     """List estimates with optional filtering.
+
+    By default the `line_items` array is stripped from each estimate in the
+    response to keep list calls within MCP tool-response size limits
+    (line_items can account for ~70% of an estimate's payload size). This
+    mirrors the summary-vs-detail split that most REST APIs use for list
+    endpoints. To fetch full line_items for one estimate, use
+    get_estimate_details. To include line_items in every estimate of this
+    list call, pass include_line_items=True — but note that large result
+    sets can then exceed MCP tool-response size limits.
 
     Args:
         client_id: Only return estimates belonging to the client with the given ID
@@ -359,10 +369,13 @@ async def list_estimates(
         to_date: Only return estimates with an issue_date on or before the given date (YYYY-MM-DD)
         state: Only return estimates with a matching state. One of: draft, sent, accepted, declined
         page: The page number to use in pagination (default: 1)
-        per_page: The number of records to return per page (1-2000, default: 10;
-            Harvest's native default is 2000 but this is capped here because each
-            estimate includes nested line_items and long notes, and large result
-            sets can exceed MCP tool-response size limits)
+        per_page: The number of records to return per page (1-2000, default: 25;
+            Harvest's native default is 2000 but this wrapper uses 25 since the
+            typical summary-mode response per estimate is ~2KB)
+        include_line_items: If True, include each estimate's line_items array
+            in the response. Defaults to False. Be cautious combining this with
+            a high per_page — full estimate payloads are much larger and can
+            exceed MCP tool-response size limits.
     """
     params = {}
     if client_id is not None:
@@ -380,9 +393,14 @@ async def list_estimates(
     if per_page is not None:
         params["per_page"] = str(per_page)
     else:
-        params["per_page"] = "10"
+        params["per_page"] = "25"
 
     response = await harvest_request("estimates", params)
+
+    if not include_line_items:
+        for est in response.get("estimates", []):
+            est.pop("line_items", None)
+
     return json.dumps(response, indent=2)
 
 

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -55,8 +55,10 @@ async def harvest_request(path, params=None, method="GET"):
                 f"Harvest API Error: {response.status_code} {response.text}"
             )
 
-        # Some endpoints (e.g. DELETE) return 200 OK with no body
-        if not response.content:
+        # Harvest's DELETE endpoints may return 200 OK with no body. Scope
+        # this fallback to DELETE only — an empty body on GET/POST/PATCH is
+        # more likely a real bug that should surface as JSONDecodeError.
+        if method == "DELETE" and not response.content:
             return {"status": "ok"}
 
         return response.json()

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -400,6 +400,35 @@ async def get_estimate_details(estimate_id: int):
 
 
 @mcp.tool()
+async def get_estimate_by_number(number: str | int):
+    """Retrieve an estimate by its human-readable number (e.g. "79").
+
+    The Harvest API has no direct "get by number" endpoint, so this tool
+    lists estimates internally and filters client-side. For better
+    performance when you already know the estimate's internal id, prefer
+    get_estimate_details.
+
+    Args:
+        number: The user-facing estimate number as shown in the Harvest UI
+            (e.g. "79", "1001"). Accepts a string or integer.
+    """
+    number_str = str(number)
+    page = 1
+    while True:
+        response = await harvest_request(
+            "estimates",
+            {"page": str(page), "per_page": "2000"},
+        )
+        for est in response.get("estimates", []):
+            if est.get("number") == number_str:
+                return json.dumps(est, indent=2)
+        if not response.get("next_page"):
+            break
+        page += 1
+    raise Exception(f"No estimate found with number {number_str}")
+
+
+@mcp.tool()
 async def list_estimate_messages(
     estimate_id: int,
     updated_since: str = None,

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -641,6 +641,20 @@ async def send_estimate_message(
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def delete_estimate(estimate_id: int):
+    """Delete an estimate.
+
+    Args:
+        estimate_id: The ID of the estimate to delete
+    """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
+    response = await harvest_request(f"estimates/{estimate_id}", method="DELETE")
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -586,6 +586,57 @@ async def change_estimate_state(estimate_id: int, event_type: str):
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def send_estimate_message(
+    estimate_id: int,
+    recipients: list,
+    subject: str = None,
+    body: str = None,
+    send_me_a_copy: bool = None,
+    event_type: str = None,
+):
+    """Create an estimate message. **This sends an email to the recipients.**
+
+    Use this to email an estimate to a client. To merely change the estimate's
+    state without sending email (e.g. "mark as sent"), use change_estimate_state
+    instead.
+
+    Note: If the estimate is in "draft" state, sending any message with
+    recipients will automatically transition it to "sent" (even without
+    passing event_type). This matches Harvest's UI behavior — emailing
+    implies sending.
+
+    Args:
+        estimate_id: The ID of the estimate to send a message for (required)
+        recipients: Array of recipient objects (required). Each must have:
+            - email (string, required): Email address of the recipient
+            - name (string, optional): Display name of the recipient
+            Example: [{"name": "Jane Doe", "email": "jane@example.com"}]
+        subject: The message subject
+        body: The message body
+        send_me_a_copy: If true, a copy of the email is sent to the current user (default false)
+        event_type: Optionally also run a state transition alongside the email.
+            One of: "send", "accept", "decline", "re-open".
+    """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
+    params = {"recipients": recipients}
+    if subject is not None:
+        params["subject"] = subject
+    if body is not None:
+        params["body"] = body
+    if send_me_a_copy is not None:
+        params["send_me_a_copy"] = send_me_a_copy
+    if event_type is not None:
+        params["event_type"] = event_type
+
+    response = await harvest_request(
+        f"estimates/{estimate_id}/messages", params, method="POST"
+    )
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -488,6 +488,79 @@ async def create_estimate(
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def update_estimate(
+    estimate_id: int,
+    client_id: int = None,
+    number: str = None,
+    purchase_order: str = None,
+    tax: float = None,
+    tax2: float = None,
+    discount: float = None,
+    subject: str = None,
+    notes: str = None,
+    currency: str = None,
+    issue_date: str = None,
+    line_items: list = None,
+):
+    """Update an existing estimate.
+
+    Only the parameters you provide are changed; omitted parameters
+    remain untouched.
+
+    Args:
+        estimate_id: The ID of the estimate to update (required)
+        client_id: The ID of the client this estimate belongs to
+        number: Estimate number
+        purchase_order: The purchase order number
+        tax: Tax percentage applied to the subtotal (e.g. 10.0 for 10%)
+        tax2: Second tax percentage applied to the subtotal
+        discount: Discount percentage subtracted from the subtotal
+        subject: The estimate subject
+        notes: Any additional notes to include on the estimate
+        currency: Currency code (e.g. "CHF", "EUR", "USD")
+        issue_date: Date the estimate was issued (YYYY-MM-DD)
+        line_items: Array of line item objects. To modify the estimate's
+            line items:
+            - Add a new item: include an object with kind/description/
+              quantity/unit_price/taxed/taxed2 (no "id")
+            - Update an existing item: include the item's id plus the
+              fields to change
+            - Delete an existing item: include the item's id and set
+              "_destroy": true
+            Items not referenced in the request are left untouched.
+    """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
+    params = {}
+    if client_id is not None:
+        params["client_id"] = client_id
+    if number is not None:
+        params["number"] = number
+    if purchase_order is not None:
+        params["purchase_order"] = purchase_order
+    if tax is not None:
+        params["tax"] = tax
+    if tax2 is not None:
+        params["tax2"] = tax2
+    if discount is not None:
+        params["discount"] = discount
+    if subject is not None:
+        params["subject"] = subject
+    if notes is not None:
+        params["notes"] = notes
+    if currency is not None:
+        params["currency"] = currency
+    if issue_date is not None:
+        params["issue_date"] = issue_date
+    if line_items is not None:
+        params["line_items"] = line_items
+
+    response = await harvest_request(f"estimates/{estimate_id}", params, method="PATCH")
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -391,7 +391,9 @@ async def get_estimate_details(estimate_id: int):
     """Retrieve details for a specific estimate.
 
     Args:
-        estimate_id: The ID of the estimate to retrieve
+        estimate_id: The internal integer ID of the estimate (e.g. 4019251),
+            NOT the user-facing number ("79") shown in the Harvest UI.
+            Use get_estimate_by_number if you only have the number.
     """
     response = await harvest_request(f"estimates/{estimate_id}")
     return json.dumps(response, indent=2)
@@ -409,7 +411,9 @@ async def list_estimate_messages(
     Messages are returned sorted by creation date, most recent first.
 
     Args:
-        estimate_id: The ID of the estimate to list messages for
+        estimate_id: The internal integer ID of the estimate (e.g. 4019251),
+            NOT the user-facing number ("79"). Use get_estimate_by_number
+            if you only have the number.
         updated_since: Only return messages updated since the given datetime (e.g. 2021-04-09T12:48:29Z)
         page: The page number for pagination (default: 1). Deprecated by Harvest
             in favor of cursor-based pagination via the response's links.next URL.
@@ -513,7 +517,9 @@ async def update_estimate(
     remain untouched.
 
     Args:
-        estimate_id: The ID of the estimate to update (required)
+        estimate_id: The internal integer ID of the estimate to update
+            (e.g. 4019251), NOT the user-facing number ("79"). Use
+            get_estimate_by_number if you only have the number.
         client_id: The ID of the client this estimate belongs to
         number: Estimate number
         purchase_order: The purchase order number
@@ -573,7 +579,9 @@ async def change_estimate_state(estimate_id: int, event_type: str):
     email the estimate to recipients, use send_estimate_message instead.
 
     Args:
-        estimate_id: The ID of the estimate to transition
+        estimate_id: The internal integer ID of the estimate to transition
+            (e.g. 4019251), NOT the user-facing number ("79"). Use
+            get_estimate_by_number if you only have the number.
         event_type: One of:
             - "send": mark a draft estimate as sent
             - "accept": mark a sent estimate as accepted (closes it)
@@ -611,7 +619,9 @@ async def send_estimate_message(
     implies sending.
 
     Args:
-        estimate_id: The ID of the estimate to send a message for (required)
+        estimate_id: The internal integer ID of the estimate to send a
+            message for (e.g. 4019251), NOT the user-facing number ("79").
+            Use get_estimate_by_number if you only have the number.
         recipients: Array of recipient objects (required). Each must have:
             - email (string, required): Email address of the recipient
             - name (string, optional): Display name of the recipient
@@ -646,7 +656,9 @@ async def delete_estimate(estimate_id: int):
     """Delete an estimate.
 
     Args:
-        estimate_id: The ID of the estimate to delete
+        estimate_id: The internal integer ID of the estimate to delete
+            (e.g. 4019251), NOT the user-facing number ("79"). Use
+            get_estimate_by_number if you only have the number.
     """
     if HARVEST_READ_ONLY:
         return READ_ONLY_MESSAGE

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -55,6 +55,10 @@ async def harvest_request(path, params=None, method="GET"):
                 f"Harvest API Error: {response.status_code} {response.text}"
             )
 
+        # Some endpoints (e.g. DELETE) return 200 OK with no body
+        if not response.content:
+            return {"status": "ok"}
+
         return response.json()
 
 

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -492,7 +492,7 @@ async def create_estimate(
     notes: str = None,
     currency: str = None,
     issue_date: str = None,
-    line_items: list = None,
+    line_items: list[dict] = None,
 ):
     """Create a new estimate.
 
@@ -558,7 +558,7 @@ async def update_estimate(
     notes: str = None,
     currency: str = None,
     issue_date: str = None,
-    line_items: list = None,
+    line_items: list[dict] = None,
 ):
     """Update an existing estimate.
 
@@ -650,7 +650,7 @@ async def change_estimate_state(estimate_id: int, event_type: str):
 @mcp.tool()
 async def send_estimate_message(
     estimate_id: int,
-    recipients: list,
+    recipients: list[dict],
     subject: str = None,
     body: str = None,
     send_me_a_copy: bool = None,

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -423,6 +423,71 @@ async def list_estimate_messages(
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def create_estimate(
+    client_id: int,
+    number: str = None,
+    purchase_order: str = None,
+    tax: float = None,
+    tax2: float = None,
+    discount: float = None,
+    subject: str = None,
+    notes: str = None,
+    currency: str = None,
+    issue_date: str = None,
+    line_items: list = None,
+):
+    """Create a new estimate.
+
+    Args:
+        client_id: The ID of the client this estimate belongs to (required)
+        number: Estimate number. If omitted, Harvest auto-generates one
+        purchase_order: The purchase order number
+        tax: Tax percentage applied to the subtotal (e.g. 10.0 for 10%)
+        tax2: Second tax percentage applied to the subtotal
+        discount: Discount percentage subtracted from the subtotal
+        subject: The estimate subject
+        notes: Any additional notes to include on the estimate
+        currency: Currency code (e.g. "CHF", "EUR", "USD"). Defaults to the client's currency
+        issue_date: Date the estimate was issued (YYYY-MM-DD). Defaults to today
+        line_items: Array of line item objects. Each item supports:
+            - kind (string, required): Estimate item category name (e.g. "Service", "Product")
+            - description (string, optional): Text description of the line item
+            - quantity (number, optional, defaults to 1): Unit quantity. Harvest's
+              docs state integer but decimals (e.g. 0.25, 0.75) are accepted in practice.
+            - unit_price (decimal, required): Individual price per unit
+            - taxed (boolean, optional, defaults to false): Whether tax applies
+            - taxed2 (boolean, optional, defaults to false): Whether tax2 applies
+    """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
+    params = {"client_id": client_id}
+    if number is not None:
+        params["number"] = number
+    if purchase_order is not None:
+        params["purchase_order"] = purchase_order
+    if tax is not None:
+        params["tax"] = tax
+    if tax2 is not None:
+        params["tax2"] = tax2
+    if discount is not None:
+        params["discount"] = discount
+    if subject is not None:
+        params["subject"] = subject
+    if notes is not None:
+        params["notes"] = notes
+    if currency is not None:
+        params["currency"] = currency
+    if issue_date is not None:
+        params["issue_date"] = issue_date
+    if line_items is not None:
+        params["line_items"] = line_items
+
+    response = await harvest_request("estimates", params, method="POST")
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -561,6 +561,31 @@ async def update_estimate(
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def change_estimate_state(estimate_id: int, event_type: str):
+    """Change the state of an estimate by creating a state-transition message.
+
+    This does not email the estimate — it only changes its state. To actually
+    email the estimate to recipients, use send_estimate_message instead.
+
+    Args:
+        estimate_id: The ID of the estimate to transition
+        event_type: One of:
+            - "send": mark a draft estimate as sent
+            - "accept": mark a sent estimate as accepted (closes it)
+            - "decline": mark a sent estimate as declined (closes it)
+            - "re-open": reopen a closed (accepted/declined) estimate back to sent
+    """
+    if HARVEST_READ_ONLY:
+        return READ_ONLY_MESSAGE
+
+    params = {"event_type": event_type}
+    response = await harvest_request(
+        f"estimates/{estimate_id}/messages", params, method="POST"
+    )
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -382,6 +382,17 @@ async def list_estimates(
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def get_estimate_details(estimate_id: int):
+    """Retrieve details for a specific estimate.
+
+    Args:
+        estimate_id: The ID of the estimate to retrieve
+    """
+    response = await harvest_request(f"estimates/{estimate_id}")
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -336,6 +336,52 @@ async def get_unsubmitted_timesheets(
     return json.dumps(filtered_response, indent=2)
 
 
+@mcp.tool()
+async def list_estimates(
+    client_id: int = None,
+    updated_since: str = None,
+    from_date: str = None,
+    to_date: str = None,
+    state: str = None,
+    page: int = None,
+    per_page: int = None,
+):
+    """List estimates with optional filtering.
+
+    Args:
+        client_id: Only return estimates belonging to the client with the given ID
+        updated_since: Only return estimates updated since the given datetime (e.g. 2021-04-09T12:48:29Z)
+        from_date: Only return estimates with an issue_date on or after the given date (YYYY-MM-DD)
+        to_date: Only return estimates with an issue_date on or before the given date (YYYY-MM-DD)
+        state: Only return estimates with a matching state. One of: draft, sent, accepted, declined
+        page: The page number to use in pagination (default: 1)
+        per_page: The number of records to return per page (1-2000, default: 10;
+            Harvest's native default is 2000 but this is capped here because each
+            estimate includes nested line_items and long notes, and large result
+            sets can exceed MCP tool-response size limits)
+    """
+    params = {}
+    if client_id is not None:
+        params["client_id"] = str(client_id)
+    if updated_since is not None:
+        params["updated_since"] = updated_since
+    if from_date is not None:
+        params["from"] = from_date
+    if to_date is not None:
+        params["to"] = to_date
+    if state is not None:
+        params["state"] = state
+    if page is not None:
+        params["page"] = str(page)
+    if per_page is not None:
+        params["per_page"] = str(per_page)
+    else:
+        params["per_page"] = "10"
+
+    response = await harvest_request("estimates", params)
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/harvest-mcp-server.py
+++ b/harvest-mcp-server.py
@@ -393,6 +393,36 @@ async def get_estimate_details(estimate_id: int):
     return json.dumps(response, indent=2)
 
 
+@mcp.tool()
+async def list_estimate_messages(
+    estimate_id: int,
+    updated_since: str = None,
+    page: int = None,
+    per_page: int = None,
+):
+    """List messages associated with an estimate.
+
+    Messages are returned sorted by creation date, most recent first.
+
+    Args:
+        estimate_id: The ID of the estimate to list messages for
+        updated_since: Only return messages updated since the given datetime (e.g. 2021-04-09T12:48:29Z)
+        page: The page number for pagination (default: 1). Deprecated by Harvest
+            in favor of cursor-based pagination via the response's links.next URL.
+        per_page: The number of records to return per page (1-2000, default: 2000)
+    """
+    params = {}
+    if updated_since is not None:
+        params["updated_since"] = updated_since
+    if page is not None:
+        params["page"] = str(page)
+    if per_page is not None:
+        params["per_page"] = str(per_page)
+
+    response = await harvest_request(f"estimates/{estimate_id}/messages", params)
+    return json.dumps(response, indent=2)
+
+
 if __name__ == "__main__":
     # Initialize and run the server
     mcp.run(transport="stdio")

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ The server provides the following functionality:
 ### Estimates
 - List estimates with filtering options (by client, state, date range, updated_since)
 - Retrieve detailed estimate information
+- Look up an estimate by its user-facing number (e.g. "79")
 - List messages associated with an estimate
 - Create new estimates with line items
 - Update existing estimates (add/update/delete line items via `_destroy`)
@@ -91,6 +92,7 @@ Once connected, you can ask Claude about your Harvest data with queries like:
 - "Get my unsubmitted timesheets from this month"
 - "Show me unsubmitted time entries for user [user_id]"
 - "Show me all accepted estimates from this quarter"
+- "Find the estimate numbered [number]"
 - "Create a draft estimate for client [client_id] with these line items..."
 - "Mark estimate [id] as sent"
 - "Email estimate [id] to client@example.com"

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,16 @@ The server provides the following functionality:
 ### Tasks
 - List available tasks with filtering options
 
+### Estimates
+- List estimates with filtering options (by client, state, date range, updated_since)
+- Retrieve detailed estimate information
+- List messages associated with an estimate
+- Create new estimates with line items
+- Update existing estimates (add/update/delete line items via `_destroy`)
+- Change estimate state (send, accept, decline, re-open) without sending email
+- Send estimate messages (emails the estimate to recipients)
+- Delete estimates
+
 ## Setup Instructions
 
 ### Prerequisites
@@ -80,6 +90,10 @@ Once connected, you can ask Claude about your Harvest data with queries like:
 - "List all available tasks"
 - "Get my unsubmitted timesheets from this month"
 - "Show me unsubmitted time entries for user [user_id]"
+- "Show me all accepted estimates from this quarter"
+- "Create a draft estimate for client [client_id] with these line items..."
+- "Mark estimate [id] as sent"
+- "Email estimate [id] to client@example.com"
 
 ## Customization
 
@@ -93,7 +107,7 @@ You can modify the server code to add more functionality or customize the existi
 
 ## Read-Only Mode
 
-You can run the server in read-only mode by setting the `HARVEST_READ_ONLY` environment variable to `true`. This disables all write operations (creating time entries, starting timers, and stopping timers) while keeping all read operations available.
+You can run the server in read-only mode by setting the `HARVEST_READ_ONLY` environment variable to `true`. This disables all write operations (creating time entries, starting/stopping timers, creating/updating/deleting estimates, changing estimate state, and sending estimate messages) while keeping all read operations available.
 
 ```json
 {


### PR DESCRIPTION
## Summary

Adds full support for Harvest's [Estimates API](https://help.getharvest.com/api-v2/estimates-api/estimates/estimates/) to the MCP server — the one major resource not yet covered. The current server handles time entries, projects, clients, tasks, and users; this PR extends it with 8 new tools plus one small defensive fix to the shared request helper.

## What's added

| Tool | Verb | Endpoint |
|---|---|---|
| `list_estimates` | GET | `/v2/estimates` |
| `get_estimate_details` | GET | `/v2/estimates/{id}` |
| `list_estimate_messages` | GET | `/v2/estimates/{id}/messages` |
| `create_estimate` | POST | `/v2/estimates` |
| `update_estimate` | PATCH | `/v2/estimates/{id}` |
| `change_estimate_state` | POST | `/v2/estimates/{id}/messages` (event_type only) |
| `send_estimate_message` | POST | `/v2/estimates/{id}/messages` (with recipients) |
| `delete_estimate` | DELETE | `/v2/estimates/{id}` |

All write tools honor the existing `HARVEST_READ_ONLY` guard.

## Design choices

- **Line items as a JSON blob.** `create_estimate` and `update_estimate` expose `line_items` as a `list` parameter (array of dicts), matching the shape Harvest accepts directly. Keeps the tool count manageable (1 tool covers add/update/delete-per-item via the `_destroy` flag) and avoids duplicating the schema across multiple sub-tools.
- **State vs. email split into two tools.** `change_estimate_state` and `send_estimate_message` both POST to `/messages`, but with different payload shapes — one passes only `event_type`, the other requires `recipients`. Separating them into two tools makes LLM call-sites unambiguous: "mark as sent" cannot accidentally become "email the client".
- **Conservative `per_page` default on `list_estimates` (10 vs Harvest's native 2000).** Estimates include nested `line_items` and long `notes`; a naive fetch of 2000 records can overflow MCP tool-response size limits. 10 matches the pattern of `list_users` / `get_unsubmitted_timesheets` setting conservative LLM-friendly defaults for heavy resources. Callers can always pass `per_page` explicitly when they genuinely need bulk.
- **Doc-order parameter layout.** Tool signatures follow the parameter order from the Harvest docs (client_id, number, purchase_order, tax, tax2, discount, subject, notes, currency, issue_date, line_items) for easier cross-reference during review.

## Empirical findings worth documenting inline

Two behaviors aren't explicitly called out in the Harvest docs but matter for users; both are noted in the relevant docstrings:

1. **`line_items[].quantity` accepts decimals despite the docs saying `integer`.** Real-world data uses fractional quantities like 0.25 and 0.75. The API accepts them; the docs just lag.
2. **Posting a message with recipients on a draft estimate auto-transitions it to `sent`.** No `event_type` needed. `send_estimate_message`'s docstring flags this so callers aren't surprised.

## Helper fix (separate commit)

`harvest_request` used to blindly call `response.json()` on every 200 OK. That would raise `JSONDecodeError` on any endpoint returning an empty body. Added a small fallback:

\`\`\`python
if not response.content:
    return {\"status\": \"ok\"}
\`\`\`

Harvest's DELETE on estimates *does* actually return the full deleted object in the body (verified live), so the fallback isn't triggered in practice for this PR — but the helper is now safer for any future endpoint that behaves differently.

## Testing

Every tool was exercised live against a real Harvest account before being committed; each commit on the branch represents one verified increment. Live tests performed:

- List/get verified against 71 real estimates
- Create → verified in UI, round-trip through get_estimate_details
- Update → both scalar field (notes with German umlauts + CRLF) and line-item mutation (update existing + add new)
- All four state transitions: send → decline → re-open → accept (verified timestamps and final state)
- send_estimate_message with recipient \`v@zge.la\` (my own address) — confirmed email actually delivered
- Delete → verified via 404 on subsequent get

## Notes

- No new dependencies
- No changes to existing tool signatures or behavior
- README updated with the new tools under Features + example queries + read-only-mode scope